### PR TITLE
Correção de escrita do método da doc - Inglês

### DIFF
--- a/docs/overview/first-steps.md
+++ b/docs/overview/first-steps.md
@@ -110,7 +110,7 @@ The repositories are made from a combination of `connection` + `entity`, like th
 import { ExampleEntity } from "./example.entity";
 import { connection } from "./database.connection";
 
-export const exampleRepository = connection.getRepository(ExampleEntity);
+export const exampleRepository = connection.getRepository<ExampleEntity>(ExampleEntity);
 ```
 
 ### Using your Repository


### PR DESCRIPTION
`connection.getRepository(ExampleEntity)` -> `connection.getRepository<ExampleEntity>(ExampleEntity)`